### PR TITLE
Fix issue when one crypt entry was found dialog was not shown

### DIFF
--- a/FindCrypt.java
+++ b/FindCrypt.java
@@ -966,7 +966,7 @@ public class FindCrypt extends GhidraScript {
 		}
 		
 		// Only show results if something has been found.
-		if (_ctr > 1)
+		if (_ctr >= 1)
 			GuiHandler.ShowMessage("FindCrypt Ghidra", "A total of " + _ctr + " signatures have been found.", _formatted, 1);
 		
 		


### PR DESCRIPTION
There was a small issue that if there was only one entry found the dialog was not shown. This PR fixes that.